### PR TITLE
Convert pyCapsule to python 2.6 pyobject interfaces

### DIFF
--- a/src/python-lz4f.c
+++ b/src/python-lz4f.c
@@ -45,6 +45,12 @@
 
 #define CHECK(cond, ...) if (LZ4F_isError(cond)) { printf("%s%s", "Error => ", LZ4F_getErrorName(cond)); goto _output_error; }
 
+
+#ifndef Py_CAPSULE_H
+#define PyCapsule_New(cobj, name, destr) PyCObject_FromVoidPtr((cobj), NULL)
+#define PyCapsule_GetPointer(cobj, name) PyCObject_AsVoidPtr((cobj))
+#endif
+
 static int LZ4S_GetBlockSize_FromBlockId (int id) { return (1 << (8 + (2 * id))); }
 
 /* Compression methods */


### PR DESCRIPTION
PyCapsule interfaces missing in python 2.6. Define the micros to convert pycapsule to pyobject.