### PR TITLE
fix bug: lz4toolsCli -d arguments not working

### DIFF
--- a/lz4tools/__main__.py
+++ b/lz4tools/__main__.py
@@ -73,6 +73,8 @@ elif res.tar:
     if res.decomp:
         outErr()
     compDir()
+elif res.decomp:
+    decompFile()
 elif res.input.endswith('lz4'):
     decompFile()
 elif os.path.isfile(res.input):


### PR DESCRIPTION
fix bug: lz4toolsCli -d arguments not working
