### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
+arch:
+   - amd64
+   - ppc64le
 language: python
 python:
 #  - 2.6
   - 2.7
   - 3.3
   - 3.4
+matrix:
+   allow_failures:
+      - python: 3.3 #EOL
 install: 
 script: python setup.py test
 os:


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/lz4tools/builds/198462946 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!